### PR TITLE
Use "noname" for user in newly created auth-source entries

### DIFF
--- a/totp.el
+++ b/totp.el
@@ -79,8 +79,8 @@ command `totp'."
 if CREATE is non-nil create a new token."
   (car
    (auth-source-search
-    :host (format "TOTP:%s" account); PREFIX in order to not to come into conflict with otherentries
-    :user user-login-name
+    :host (format "TOTP:%s" account); PREFIX in order to not to come into conflict with other entries
+    :user (list "noname" user-login-name) ;;use noname for new entries
     :max 1
     :create create)))
 


### PR DESCRIPTION
user isn't used in TOTP. This change makes it possible to use ONE authinfo file on multiple systems and different ‘user-login-name’.

Also Keep searching `user-login-name' for backward compatibility. Fixes #6.