### PR TITLE
have `totp--hex-decode-string` work with odd-length strings

### DIFF
--- a/totp.el
+++ b/totp.el
@@ -106,9 +106,12 @@ if CREATE is non-nil create a new token."
 
 (defun totp--hex-decode-string (string)
   "Hex-decode STRING and return the result as a unibyte string."
+  ;; Pad the string with a leading zero if its length is odd.
+  (when (oddp (length string))
+    (setq string (concat "0" string)))
   (apply #'unibyte-string
-	 (seq-map (lambda (s) (hexl-htoi (aref s 0) (aref s 1)))
-		  (seq-partition string 2))))
+         (seq-map (lambda (s) (hexl-htoi (aref s 0) (aref s 1)))
+                  (seq-partition string 2))))
 
 ;;;###autoload
 (defun totp(string &optional time digits)


### PR DESCRIPTION
Right now, `totp--hex-decode-string` breaks when passing in a hex value with odd-length. Example `(totp--hex-decode-string "12345")`